### PR TITLE
fix: tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
           python-version: ${{ matrix.python-version }}
 
       - name: Install the project

--- a/src/torah_dl/core/extractors/outorah.py
+++ b/src/torah_dl/core/extractors/outorah.py
@@ -20,7 +20,7 @@ class OutorahExtractor(Extractor):
         ExtractionExample(
             name="main_page",
             url="https://outorah.org/p/212365",
-            download_url="https://media.ou.org/audio/torat_imecha_parsha/ti_miketz_85-1734986492.mp3",
+            download_url="https://media.ou.org/torah/4093/212365/212365.mp3",
             title="Parshat Miketz: A Chanukah Charade",
             file_format="audio/mp3",
             valid=True,

--- a/src/torah_dl/core/extractors/torahapp.py
+++ b/src/torah_dl/core/extractors/torahapp.py
@@ -33,7 +33,7 @@ class TorahAppExtractor(Extractor):
         ExtractionExample(
             name="ou_lecture",
             url="https://thetorahapp.org/share/p/OU_4106?e=http%3A%2F%2Foutorah.org%2Fp%2F81351",
-            download_url="https://media.ou.org/audio/parsha/rabbi-zecharia-resnik/bo-5.mp3",
+            download_url="https://media.ou.org/torah/4106/81351/81351.mp3",
             title="Bo - Chamishi",
             file_format="audio/mp3",
             valid=True,

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -472,7 +472,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -1208,7 +1208,7 @@ wheels = [
 
 [[package]]
 name = "torah-dl"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
This pull request includes changes to update download URLs in extractor classes and modify the workflow configuration. The most important changes are grouped by theme below:

### Workflow Configuration:

* [`.github/workflows/workflow.yml`](diffhunk://#diff-126bf89616b7daa3d14ebc882ad18666aaf1c3dae888c4ba306a66ec80758bc1L79): Removed the `enable-cache` parameter from the `Install uv` step.

### Extractor Classes:

* [`src/torah_dl/core/extractors/outorah.py`](diffhunk://#diff-8050ef265bbf3ac9c1dd7797c74e19ca953e0f11a383071020f56bd5ce24f84eL23-R23): Updated the `download_url` in the `OutorahExtractor` class to a new URL format.
* [`src/torah_dl/core/extractors/torahapp.py`](diffhunk://#diff-2dcc74b855b044bfc00230d35ad1118f2c6543bb213316b21224ae1cdf7a29adL36-R36): Updated the `download_url` in the `TorahAppExtractor` class to a new URL format.