### PR TITLE
feat(cli): improve extract command output formatting

### DIFF
--- a/src/torah_dl/cli.py
+++ b/src/torah_dl/cli.py
@@ -37,7 +37,10 @@ def extract_url(
         typer.echo(extraction.download_url)
     else:
         table = Table(box=None, pad_edge=False)
-        table.add_row("Title", extraction.title, style="cyan")
+        table.add_column(style="bold")
+        # Set no_wrap=True to display full URL
+        table.add_column(style="cyan", no_wrap=True)
+        table.add_row("Title", extraction.title)
         table.add_row("Download URL", extraction.download_url, style="green")
         console.print(table)
 


### PR DESCRIPTION
The CLI output is cutting the table text short causing the download URL to not open correctly. This PR adds `no_wrap=True` to to the table to avoid this issue. 

After Changes:
<img width="1102" alt="Screenshot 2025-06-30 at 12 18 21 PM" src="https://github.com/user-attachments/assets/4b2cbe7e-238d-4a9e-945b-493684f50c96" />
