### PR TITLE
fix: support YUTorah legacy lecture.cfm URL format

### DIFF
--- a/src/torah_dl/core/extractors/yutorah.py
+++ b/src/torah_dl/core/extractors/yutorah.py
@@ -52,6 +52,14 @@ class YutorahExtractor(Extractor):
             file_format="",
             valid=False,
         ),
+        ExtractionExample(
+            name="lecture_cfm_link",
+            url="https://www.yutorah.org/lectures/lecture.cfm/1163859",
+            download_url="https://download.yutorah.org/2026/15203/1163859/beis-din--secular-courts-arkaos.mp3",
+            title="Beis Din & Secular Courts (Arkaos)",
+            file_format="audio/mp3",
+            valid=True,
+        ),
     ]
 
     # URL pattern for YUTorah.org pages
@@ -108,6 +116,8 @@ class YutorahExtractor(Extractor):
         query = parse_qs(urlparse(url).query)
         if shiurid := query.get("shiurid", [None])[0]:
             return shiurid
+        if match := re.search(r"/lectures/lecture\.cfm/(\d+)", url):
+            return match.group(1)
         if match := re.search(r"/lectures/(\d+)", url):
             return match.group(1)
         if match := re.search(r"/sidebar/lecturedata/(\d+)", url):


### PR DESCRIPTION
> *This PR was drafted with AI assistance (GitHub Copilot).*

## Summary

Adds support for YUTorah's legacy `/lectures/lecture.cfm/{id}` URL format in the `_extract_shiur_id` method.

## Problem

Sites like [Torah Musings Audio Roundup](https://www.torahmusings.com/category/audio/) link to YUTorah using the `lecture.cfm` format:
\\\
https://www.yutorah.org/lectures/lecture.cfm/1163859
\\\

This fails with `ContentExtractionError` because the existing regex `/lectures/(\d+)` doesn't match when `lecture.cfm` sits between `/lectures/` and the numeric ID.

## Changes

- Added a regex pattern to `_extract_shiur_id` for `/lectures/lecture.cfm/(\d+)` (placed before the generic `/lectures/(\d+)` pattern)
- Added a new `ExtractionExample` (`lecture_cfm_link`) for automated test coverage

## Testing

All 10 YUTorah extractor tests pass, including the new `lecture_cfm_link` example.

Fixes #193