### PR TITLE
fix: yuTorah error fix

### DIFF
--- a/src/torah_dl/core/extractors/yutorah.py
+++ b/src/torah_dl/core/extractors/yutorah.py
@@ -63,10 +63,14 @@ class YutorahExtractor(Extractor):
     ]
 
     # URL pattern for YUTorah.org pages
-    URL_PATTERN = re.compile(r"https?://(?:www\.)?yutorah\.org/")
+    URL_PATTERN = re.compile(r"https?://(?:[\w-]+\.)?yutorah\.org/", re.IGNORECASE)
 
     DOWNLOAD_URL_PATTERN = re.compile(r"https?://[^\"'\s>]+\.mp3(?:\?[^\"'\s<]*)?", re.IGNORECASE)
-    SHIUR_ID_PATTERN = re.compile(r"/(?:lectures|sidebar/lecturedata)/(?:details\?shiurid=)?(\d+)")
+    SHIUR_ID_PATTERNS = [  # noqa: RUF012
+        re.compile(r"^/lectures/(\d+)(?:/|$)", re.IGNORECASE),
+        re.compile(r"^/lectures/lecture(?:_iframe)?\.cfm/(\d+)(?:/|$)", re.IGNORECASE),
+        re.compile(r"^/sidebar/lecturedata/(\d+)(?:/|$)", re.IGNORECASE),
+    ]
 
     @property
     def url_patterns(self) -> list[Pattern]:
@@ -76,6 +80,9 @@ class YutorahExtractor(Extractor):
             List[Pattern]: List of compiled regex patterns matching YUTorah.org URLs
         """
         return [self.URL_PATTERN]
+
+    def can_handle(self, url: str) -> bool:
+        return super().can_handle(url) and self._extract_shiur_id(url) is not None
 
     def extract(self, url: str) -> Extraction:
         """Extract download URL and title from a YUTorah.org page.
@@ -114,16 +121,14 @@ class YutorahExtractor(Extractor):
 
     def _extract_shiur_id(self, url: str) -> str | None:
         query = parse_qs(urlparse(url).query)
-        if shiurid := query.get("shiurid", [None])[0]:
-            return shiurid
-        if match := re.search(r"/lectures/lecture\.cfm/(\d+)", url):
-            return match.group(1)
-        if match := re.search(r"/lectures/(\d+)", url):
-            return match.group(1)
-        if match := re.search(r"/sidebar/lecturedata/(\d+)", url):
-            return match.group(1)
-        if match := self.SHIUR_ID_PATTERN.search(url):
-            return match.group(1)
+        for key, values in query.items():
+            if key.lower() == "shiurid" and values and values[0]:
+                return values[0]
+
+        path = urlparse(url).path
+        for pattern in self.SHIUR_ID_PATTERNS:
+            if match := pattern.search(path):
+                return match.group(1)
         return None
 
     def _extract_title(self, html: str) -> str | None:

--- a/test/test_core/test_yutorah.py
+++ b/test/test_core/test_yutorah.py
@@ -1,0 +1,62 @@
+import pytest
+
+from torah_dl.core.extractors.yutorah import YutorahExtractor
+
+
+@pytest.mark.parametrize(
+    ("url", "shiur_id"),
+    [
+        ("https://www.yutorah.org/lectures/details?shiurid=1117409", "1117409"),
+        ("https://yutorah.org/lectures/details?shiurID=1163252", "1163252"),
+        ("https://v4.yutorah.org/lectures/details?shiurId=1148315", "1148315"),
+        ("https://www.yutorah.org/lectures/1116616/Praying-for-Rain", "1116616"),
+        ("https://classic.yutorah.org/lectures/lecture_iframe.cfm/1116616", "1116616"),
+        ("https://classic.yutorah.org/lectures/lecture.cfm/1116616", "1116616"),
+        ("https://yutorah.org/sidebar/lecturedata/1116616", "1116616"),
+    ],
+)
+def test_extract_shiur_id_from_yutorah_url_variants(url: str, shiur_id: str):
+    assert YutorahExtractor()._extract_shiur_id(url) == shiur_id
+
+
+def test_can_handle_current_yutorah_url_variants():
+    extractor = YutorahExtractor()
+
+    assert extractor.can_handle("https://yutorah.org/lectures/details?shiurID=1163252")
+    assert extractor.can_handle("https://v4.yutorah.org/lectures/details?shiurID=1148315")
+    assert extractor.can_handle("https://classic.yutorah.org/lectures/lecture_iframe.cfm/1116616")
+    assert not extractor.can_handle("https://www.yutorah.org/series/bmp-shiurim")
+
+
+def test_extract_uses_case_insensitive_shiur_id_query(monkeypatch):
+    requested: dict[str, str] = {}
+
+    class Response:
+        text = """
+        <html>
+            <head><title>YUTorah Online - Sample Shiur (Rabbi Example)</title></head>
+            <body>https://download.yutorah.org/2026/1/1163252/sample-shiur.mp3</body>
+        </html>
+        """
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url: str, timeout: int, headers: dict[str, str]):
+        requested["url"] = url
+        requested["user_agent"] = headers["User-Agent"]
+        assert timeout == 30
+        return Response()
+
+    monkeypatch.setattr("torah_dl.core.extractors.yutorah.requests.get", fake_get)
+
+    extraction = YutorahExtractor().extract("https://yutorah.org/lectures/details?shiurID=1163252")
+
+    assert requested == {
+        "url": "https://classic.yutorah.org/lectures/lecture_iframe.cfm/1163252",
+        "user_agent": "torah-dl/1.0",
+    }
+    assert extraction.download_url == "https://download.yutorah.org/2026/1/1163252/sample-shiur.mp3"
+    assert extraction.file_name == "sample-shiur.mp3"
+    assert extraction.title == "Sample Shiur"
+    assert extraction.file_format == "audio/mp3"


### PR DESCRIPTION
## Summary
- Broaden YUTorah URL handling to accept current subdomains and lecture path variants
- Parse `shiurID` case-insensitively so current details links extract correctly
- Tighten `can_handle` so non-lecture YUTorah pages fall through instead of failing during extraction
- Add focused tests covering URL parsing, handling, and a mocked extraction path

## Testing
- `uv run ruff check .`
- `uv run pytest test/test_core/test_yutorah.py -vv -s`
- `uv run pytest test/test_core/test_extractors.py test/test_core/test_extract.py -k YutorahExtractor -vv -s`
- Live smoke test against a real YUTorah `shiurID` URL confirmed successful extraction